### PR TITLE
puts whole_error directly

### DIFF
--- a/lib/unix_utils.rb
+++ b/lib/unix_utils.rb
@@ -312,7 +312,7 @@ module UnixUtils
     error.rewind
     unless (whole_error = error.read).empty?
       $stderr.puts "[unix_utils] `#{argv.join(' ')}` STDERR:"
-      $stderr.puts whole_error.read
+      $stderr.puts whole_error
     end
 
     unless output_redirected


### PR DESCRIPTION
Hi @seamusabshere, found a small issue in unix_utils.

I got a NoMethodError when I run this:

`UnixUtils.sed("/Users/leo.liang/20120312/test.csv",":a","'1,10!{P;N;D;};N;ba'")`

Error message is:

```
NoMethodError: undefined method `read' for "sed: 1: \"'1,10!{P;N;D;};N;ba'\n\": invalid command code '\n":String
    from /Users/leo.liang/.rvm/gems/ruby-1.8.7-p352@data/gems/unix_utils-0.0.3/lib/unix_utils.rb:315:in `spawn'
    from /Users/leo.liang/.rvm/gems/ruby-1.8.7-p352@data/gems/unix_utils-0.0.3/lib/unix_utils.rb:200:in `sed'
```

cause for this issue is whole_error is a string, it don't have a read method.
